### PR TITLE
contrib/dimfeld/httptreemux/v5: rename env var

### DIFF
--- a/contrib/dimfeld/httptreemux/v5/option.go
+++ b/contrib/dimfeld/httptreemux/v5/option.go
@@ -24,7 +24,7 @@ type routerConfig struct {
 type RouterOption func(*routerConfig)
 
 func defaults(cfg *routerConfig) {
-	if internal.BoolEnv("DD_TRACE_HTTPROUTER_ANALYTICS_ENABLED", false) {
+	if internal.BoolEnv("DD_TRACE_HTTPTREEMUX_ANALYTICS_ENABLED", false) {
 		cfg.analyticsRate = 1.0
 	} else {
 		cfg.analyticsRate = globalconfig.AnalyticsRate()


### PR DESCRIPTION
This is a tiny PR to fix something I noticed while doing the current investigation into the unmatched resource names.

In short there is a environment variable that controls whether the trace analytics is enabled. This variable name includes `HTTPROUTER`, but it should rather be `HTTPTREEMUX` to correctly reflect what the underlying routing package is.

The PR destination is intentionally set to branch `dv/1520/add-support-for-dimfeld-httptreemux` instead of `main` to fix the code we are actually using and to also fix the PR we have against the upstream repo.

This is a low risk change since we are not using or setting this variable anywhere.