### PR TITLE
contrib/dimfeld/httptreemux/v5: add resource namer

### DIFF
--- a/contrib/dimfeld/httptreemux/v5/httptreemux.go
+++ b/contrib/dimfeld/httptreemux/v5/httptreemux.go
@@ -58,12 +58,12 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 func defaultResourceNamer(router *Router, w http.ResponseWriter, req *http.Request) string {
 	route := req.URL.Path
 	lr, found := router.Lookup(w, req)
+	if !found {
+		return req.Method + " unknown"
+	}
 	for k, v := range lr.Params {
 		// replace parameter values in URL path with their names
 		route = strings.Replace(route, v, ":"+k, 1)
 	}
-	if found {
-		return req.Method + " " + route
-	}
-	return req.Method + " unknown"
+	return req.Method + " " + route
 }

--- a/contrib/dimfeld/httptreemux/v5/httptreemux_test.go
+++ b/contrib/dimfeld/httptreemux/v5/httptreemux_test.go
@@ -130,6 +130,73 @@ func TestAnalyticsSettings(t *testing.T) {
 	})
 }
 
+func TestDefaultResourceNamer(t *testing.T) {
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	// Send and verify a request without a handler
+	url := "/unknown/path"
+	r := httptest.NewRequest("GET", url, nil)
+	w := httptest.NewRecorder()
+	router().ServeHTTP(w, r)
+	assert.Equal(404, w.Code)
+	assert.Equal("404 page not found\n", w.Body.String())
+
+	spans := mt.FinishedSpans()
+	assert.Equal(1, len(spans))
+
+	s := spans[0]
+	assert.Equal("http.request", s.OperationName())
+	assert.Equal("my-service", s.Tag(ext.ServiceName))
+	assert.Equal("GET unknown", s.Tag(ext.ResourceName))
+	assert.Equal("404", s.Tag(ext.HTTPCode))
+	assert.Equal("GET", s.Tag(ext.HTTPMethod))
+	assert.Equal("http://example.com"+url, s.Tag(ext.HTTPURL))
+	assert.Equal("testvalue", s.Tag("testkey"))
+	assert.Equal(nil, s.Tag(ext.Error))
+}
+
+func TestResourceNamer(t *testing.T) {
+	staticName := "static resource name"
+	staticNamer := func(*Router, http.ResponseWriter, *http.Request) string {
+		return staticName
+	}
+
+	assert := assert.New(t)
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	router := New(
+		WithServiceName("my-service"),
+		WithSpanOptions(tracer.Tag("testkey", "testvalue")),
+		WithResourceNamer(staticNamer),
+	)
+
+	// Note that the router has no handlers since we expect a 404
+
+	// Send and verify a request without a handler
+	url := "/unknown/path"
+	r := httptest.NewRequest("GET", url, nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, r)
+	assert.Equal(404, w.Code)
+	assert.Equal("404 page not found\n", w.Body.String())
+
+	spans := mt.FinishedSpans()
+	assert.Equal(1, len(spans))
+
+	s := spans[0]
+	assert.Equal("http.request", s.OperationName())
+	assert.Equal("my-service", s.Tag(ext.ServiceName))
+	assert.Equal(staticName, s.Tag(ext.ResourceName))
+	assert.Equal("404", s.Tag(ext.HTTPCode))
+	assert.Equal("GET", s.Tag(ext.HTTPMethod))
+	assert.Equal("http://example.com"+url, s.Tag(ext.HTTPURL))
+	assert.Equal("testvalue", s.Tag("testkey"))
+	assert.Equal(nil, s.Tag(ext.Error))
+}
+
 func router() http.Handler {
 	router := New(
 		WithServiceName("my-service"),

--- a/contrib/dimfeld/httptreemux/v5/httptreemux_test.go
+++ b/contrib/dimfeld/httptreemux/v5/httptreemux_test.go
@@ -176,7 +176,7 @@ func TestResourceNamer(t *testing.T) {
 	// Note that the router has no handlers since we expect a 404
 
 	// Send and verify a request without a handler
-	url := "/unknown/path"
+	url := "/path/that/does/not/exist"
 	r := httptest.NewRequest("GET", url, nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, r)

--- a/contrib/dimfeld/httptreemux/v5/option.go
+++ b/contrib/dimfeld/httptreemux/v5/option.go
@@ -8,6 +8,7 @@ package httptreemux
 
 import (
 	"math"
+	"net/http"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal"
@@ -18,6 +19,7 @@ type routerConfig struct {
 	serviceName   string
 	spanOpts      []ddtrace.StartSpanOption
 	analyticsRate float64
+	resourceNamer func(*Router, http.ResponseWriter, *http.Request) string
 }
 
 // RouterOption represents an option that can be passed to New.
@@ -33,6 +35,7 @@ func defaults(cfg *routerConfig) {
 	if svc := globalconfig.ServiceName(); svc != "" {
 		cfg.serviceName = svc
 	}
+	cfg.resourceNamer = defaultResourceNamer
 }
 
 // WithServiceName sets the given service name for the returned router.
@@ -69,5 +72,13 @@ func WithAnalyticsRate(rate float64) RouterOption {
 		} else {
 			cfg.analyticsRate = math.NaN()
 		}
+	}
+}
+
+// WithResourceNamer specifies a function which will be used to obtain the
+// resource name for a given request.
+func WithResourceNamer(namer func(router *Router, w http.ResponseWriter, req *http.Request) string) RouterOption {
+	return func(cfg *routerConfig) {
+		cfg.resourceNamer = namer
 	}
 }


### PR DESCRIPTION
This PR adds a default resource namer with the option to override it via the router configuration.

This approach was copied from the instrumented router for `gorilla/mux`, see [defaultResourceNamer](https://github.com/DataDog/dd-trace-go/blob/main/contrib/gorilla/mux/mux.go#L130-L139) for details.

I also added tests for the default resource namer and when you override with a custom function.