### PR TITLE
contrib/dimfeld/httptreemux/v5: fix resource namer

### DIFF
--- a/contrib/dimfeld/httptreemux/v5/httptreemux.go
+++ b/contrib/dimfeld/httptreemux/v5/httptreemux.go
@@ -63,7 +63,9 @@ func defaultResourceNamer(router *Router, w http.ResponseWriter, req *http.Reque
 	}
 	for k, v := range lr.Params {
 		// replace parameter values in URL path with their names
-		route = strings.Replace(route, v, ":"+k, 1)
+		old := "/" + v
+		new := "/" + ":" + k
+		route = strings.Replace(route, old, new, 1)
 	}
 	return req.Method + " " + route
 }

--- a/contrib/dimfeld/httptreemux/v5/httptreemux.go
+++ b/contrib/dimfeld/httptreemux/v5/httptreemux.go
@@ -62,9 +62,16 @@ func defaultResourceNamer(router *Router, w http.ResponseWriter, req *http.Reque
 		return req.Method + " unknown"
 	}
 	for k, v := range lr.Params {
-		// replace parameter values in URL path with their names
-		old := "/" + v
-		new := "/" + ":" + k
+		// replace parameter surrounded by a set of "/", i.e. ".../:param/..."
+		old := "/" + v + "/"
+		new := "/" + ":" + k + "/"
+		if strings.Contains(route, old) {
+			route = strings.Replace(route, old, new, 1)
+			continue
+		}
+		// replace parameter at end of the path, i.e. "../:param"
+		old = "/" + v
+		new = "/" + ":" + k
 		route = strings.Replace(route, old, new, 1)
 	}
 	return req.Method + " " + route


### PR DESCRIPTION
This fixes an issue where the parameter substitution would fail if a parameter value was contained in the value of another.

For example given the path '/foo/:x/:y/bar' and the request URL '/foo/123/2/bar', '2' is the value of parameter 'y' but also contained in the value of parameter 'x', i.e. '123. This could lead to a scenario where the resource name would be '/foo/1:y3/2/bar' after the substitution.

To help address the issue and make it easier to add additional test cases, I moved the resource namer test to a table-driven test.