### PR TITLE
Add support for httptreemux.ContextMux

### DIFF
--- a/contrib/dimfeld/httptreemux/v5/httptreemux.go
+++ b/contrib/dimfeld/httptreemux/v5/httptreemux.go
@@ -51,7 +51,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	})
 }
 
-// Router is a traced version of httptreemux.ContextMux.
+// ContextRouter is a traced version of httptreemux.ContextMux.
 type ContextRouter struct {
 	*httptreemux.ContextMux
 	config *routerConfig

--- a/contrib/dimfeld/httptreemux/v5/option.go
+++ b/contrib/dimfeld/httptreemux/v5/option.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"net/http"
 
+	"github.com/dimfeld/httptreemux/v5"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal"
 	"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig"
@@ -19,7 +20,7 @@ type routerConfig struct {
 	serviceName   string
 	spanOpts      []ddtrace.StartSpanOption
 	analyticsRate float64
-	resourceNamer func(*Router, http.ResponseWriter, *http.Request) string
+	resourceNamer func(*httptreemux.TreeMux, http.ResponseWriter, *http.Request) string
 }
 
 // RouterOption represents an option that can be passed to New.
@@ -77,7 +78,7 @@ func WithAnalyticsRate(rate float64) RouterOption {
 
 // WithResourceNamer specifies a function which will be used to obtain the
 // resource name for a given request.
-func WithResourceNamer(namer func(router *Router, w http.ResponseWriter, req *http.Request) string) RouterOption {
+func WithResourceNamer(namer func(router *httptreemux.TreeMux, w http.ResponseWriter, req *http.Request) string) RouterOption {
 	return func(cfg *routerConfig) {
 		cfg.resourceNamer = namer
 	}

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,6 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
 github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
-github.com/dimfeld/httptreemux/v5 v5.4.0 h1:IiHYEjh+A7pYbhWyjmGnj5HZK6gpOOvyBXCJ+BE8/Gs=
-github.com/dimfeld/httptreemux/v5 v5.4.0/go.mod h1:QeEylH57C0v3VO0tkKraVz9oD3Uu93CKPnTLbsidvSw=
 github.com/dimfeld/httptreemux/v5 v5.5.0 h1:p8jkiMrCuZ0CmhwYLcbNbl7DDo21fozhKHQ2PccwOFQ=
 github.com/dimfeld/httptreemux/v5 v5.5.0/go.mod h1:QeEylH57C0v3VO0tkKraVz9oD3Uu93CKPnTLbsidvSw=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=


### PR DESCRIPTION
Add support for `httptreemux.ContextMux` provided with `dimfeld/httptreemux` by  adding a new constructor function called `NewWithContext`. `ContextMux` adds the matched route and parameters to the request context.

Added a new test file that focusses on testing the instrumented version of `httptreemux.ContextMux`, i.e. `ContextRouter`.